### PR TITLE
Handle Nested Iterators and In-Line For Block

### DIFF
--- a/src/template_parser.ts
+++ b/src/template_parser.ts
@@ -7,7 +7,7 @@ import { isArray, isNullOrUndefined } from 'util'
 // [^\|\n ]* -> to match only the variable and not the options (like default)
 //  *\|* *(.*) -> to match the jinja templates options separated by |
 const jinjaVariableRegex = /{{ *([^ ]{1}[^\|\n ]*) *\|* *(.*?)}}/g
-const jinjaForLoopRegex = /{% for (.+) in (.+) %}/g
+const jinjaForLoopRegex = /{% for (.+) in ([^%]+) %}/g
 const defaultRegex = /default\((.+?)\)/
 
 export default {

--- a/src/template_parser.ts
+++ b/src/template_parser.ts
@@ -152,7 +152,7 @@ function findTemplateInObject(templateName: string, object: any) {
 function duplicateTemplateVariables(variableName1: string, variableName2: string, variablesList: any) {
   const variable1Matches = findTemplateInVariables(variableName1, variablesList)
   for (const file in variable1Matches) {
-    variablesList[file][variableName2] = JSON.parse(JSON.stringify(variablesList[file][variableName1]))
+    variablesList[file][variableName2] = JSON.parse(JSON.stringify(getObjectAttributeValue(variablesList[file], variableName1)))
   }
 }
 

--- a/src/template_parser.ts
+++ b/src/template_parser.ts
@@ -7,7 +7,7 @@ import { isArray, isNullOrUndefined } from 'util'
 // [^\|\n ]* -> to match only the variable and not the options (like default)
 //  *\|* *(.*) -> to match the jinja templates options separated by |
 const jinjaVariableRegex = /{{ *([^ ]{1}[^\|\n ]*) *\|* *(.*?)}}/g
-const jinjaForLoopRegex = /{% for (.+) in ([^%]+) %}/g
+const jinjaForLoopRegex = /{% for ([^ ]+) in ([^%]+) %}/g
 const defaultRegex = /default\((.+?)\)/
 
 export default {


### PR DESCRIPTION
# Description
The current REGEX pattern for matching Jinja `for` blocks is too greedy. If a user defines a `for` block that is in line with the body, the pattern will not appropriately match the `for` block loop variable or the list variable.

Example:  
```yaml
#vars.yml
my_service:
  description: Some Service
  requires:
    - data.mount
    - docker.service
    - other.service
  exec: /usr/bin/docker start -a test1-container
```

```
[Unit]
Description={{ my_service.description }}
After={% for service in my_service.requires %}{{ service }} {% endfor %}

[Service]
ExecStart={{ my_service.exec }}
```

## Changes
* Narrow REGEX pattern to properly parse loop variable and list variable
* Resolve nested list variable, i.e. `{% for x in item.value.requires %}`